### PR TITLE
Added replicasets to the oc get all portion if for no other reason than the web-console in 3.9 is stored as that (though I would imagine other things will show up using that as well).

### DIFF
--- a/sos.sh
+++ b/sos.sh
@@ -23,7 +23,7 @@ oc get event -n $KUBECTL_PLUGINS_CURRENT_NAMESPACE -w &> $DEST/oc-get-event.txt 
 WATCH_PID=$!
 oc status -n $KUBECTL_PLUGINS_CURRENT_NAMESPACE &> $DEST/oc-status.txt
 oc get project -n $KUBECTL_PLUGINS_CURRENT_NAMESPACE -o ${KUBECTL_PLUGINS_LOCAL_FLAG_OUTPUT} &> $DEST/oc-get-project.${KUBECTL_PLUGINS_LOCAL_FLAG_OUTPUT}
-TARGET_OBJECTS="all,ds,pvc,hpa,quota,limits,sa,rolebinding"
+TARGET_OBJECTS="all,ds,pvc,hpa,quota,limits,sa,rolebinding,replicasets"
 if [ "$KUBECTL_PLUGINS_LOCAL_FLAG_INCLUDE_CONFIGMAP" == "true" ]; then
     TARGET_OBJECTS="$TARGET_OBJECTS,cm"
 fi


### PR DESCRIPTION
Tested that it does collect RS if there is one.

Did not test exactly what happens if there is no RS but I would imagine it gets treated exactly the same as normal resources that are not in a project.